### PR TITLE
 Include Switch-ID into topic publishing CMD-Value

### DIFF
--- a/MQTTClient.py
+++ b/MQTTClient.py
@@ -49,7 +49,7 @@ class MQTTClient(multiprocessing.Process):
         self.__commandQ.put(data_out)
 
     def publish(self, task):
-        topic = "%s/%s/%s/R/%s" % (self.mqttDataPrefix, task['family'], task['deviceId'], task['param'])
+        topic = "%s/%s" % (self.mqttDataPrefix, task['topic'])
         try:
             self._mqttConn.publish(topic, payload=task['payload'])
             self.logger.debug('Sending:%s' % (task))

--- a/MQTTClient.py
+++ b/MQTTClient.py
@@ -32,6 +32,7 @@ class MQTTClient(multiprocessing.Process):
         self.mqttDataPrefix = config['mqtt_prefix']
         self.mqttDataFormat = config['mqtt_format']
         self._mqttConn = mqtt.Client(client_id='RFLinkGateway')
+        self._mqttConn.username_pw_set(config['mqtt_user'], config['mqtt_password'])
         self._mqttConn.connect(config['mqtt_host'], port=config['mqtt_port'], keepalive=120)
         self._mqttConn.on_disconnect = self._on_disconnect
         self._mqttConn.on_publish = self._on_publish

--- a/SerialProcess.py
+++ b/SerialProcess.py
@@ -5,6 +5,7 @@ import time
 import serial
 
 
+
 #TODO keepalive i obsluga resetu
 
 
@@ -35,6 +36,7 @@ class SerialProcess(multiprocessing.Process):
         if len(data) > 3 and data[0] == '20':
             family = data[2]
             deviceId = data[3].split("=")[1]
+            switch = data[4].split("=")[1]
             d = {}
             for t in data[4:]:
                 token = t.split("=")
@@ -44,7 +46,12 @@ class SerialProcess(multiprocessing.Process):
                     val = d[key]
                 else:
                     val = int(d[key], 16) / 10
-                topic_out = "%s/%s/READ/%s" % (family, deviceId, key)
+                if key == "CMD":
+                    topic_out = "%s/%s/%s/READ/%s" % (family, deviceId, switch, key)
+                    
+                else:
+                    topic_out = "%s/%s/READ/%s" % (family, deviceId, key)
+                self.logger.debug('set topic to: %s' % (topic_out))
                 data_out = {
                     'method': 'publish',
                     'topic': topic_out,

--- a/config.json
+++ b/config.json
@@ -4,6 +4,8 @@
   "mqtt_prefix": "/data/RFLINK",
   "mqtt_format": "json",
   "mqtt_message_timeout": 60,
+  "mqtt_user":"yourMqttUser",
+  "mqtt_password":"yourmqttpassword",
   "rflink_tty_device": "/dev/ttyUSB0",
   "rflink_direct_output_params": [
     "BAT",

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,11 @@ Message:
 Every message received on particular MQTT topic is translated to
 RFLink Gateway and sent to 433 MHz.
 
+## Dependencies
+Install the dependencies with the following commands:
+
+sudo python3 -m pip install pyserial paho-mqtt tornado
+
 ## Configuration
 
 Whole configuration is located in config.json file.

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,28 @@ Install the dependencies with the following commands:
 
 sudo python3 -m pip install pyserial paho-mqtt tornado
 
+## Start as a Service
+
+sudo nano /lib/systemd/system/rfLink2mqtt.service
+
+[Unit]
+Description=RFLink2MQTTBridge
+After=multi-user.target
+Conflicts=getty@tty1.service
+
+[Service]
+Type=simple
+WorkingDirectory=/home/pi/RFLinkGateway/
+ExecStart=/usr/bin/python3 /home/pi/RFLinkGateway/RFLinkGateway.py
+User=root
+
+[Install]
+WantedBy=multi-user.target
+
+sudo systemctl daemon-reload
+sudo systemctl enable rfLink2mqtt.service
+
+
 ## Configuration
 
 Whole configuration is located in config.json file.
@@ -41,7 +63,7 @@ Whole configuration is located in config.json file.
   "mqtt_host": "your.mqtt.host",
   "mqtt_port": 1883,
   "mqtt_prefix": "/data/RFLINK",
-  "rflink_tty_device": "/dev/ttyUSB0",
+  "rflink_tty_device": "/dev/ttyACM0",
   "rflink_direct_output_params": ["BAT", "CMD", "SET_LEVEL", "SWITCH", "HUM", "CHIME", "PIR", "SMOKEALERT"]
 }
 ```


### PR DESCRIPTION
Added the switchID to the topic, when a CMD-Value is published. Like this, it's possible for a subscriber to easily detect the Switch-ID when an ON or OFF-Cmd is received without having to join two mqtt-messages. (In my case an openhab-switch-item)