### PR TITLE
feat: Optional replacement of spaces in MQTT topics

### DIFF
--- a/MQTTClient.py
+++ b/MQTTClient.py
@@ -84,6 +84,10 @@ class MQTTClient(multiprocessing.Process):
 
     def publish(self, task) -> None:
         topic = "%s/%s" % (self.config['mqtt_prefix'], task['topic'])
+
+        if self.config.get('mqtt_replace_spaces', False):
+            topic = topic.replace(" ", "_")
+
         if self.mqttDataFormat == 'json':
             if is_number(task['payload']):
                 task['payload'] = '{"value": ' + str(task['payload']) + '}'

--- a/config.json.sample
+++ b/config.json.sample
@@ -6,6 +6,7 @@
   "mqtt_message_timeout": 60,
   "mqtt_user":"your_mqtt_user",
   "mqtt_password":"your_mqtt_password",
+  "mqtt_replace_spaces": true,
   "rflink_tty_device": "/dev/ttyUSB0",
   "rflink_direct_output_params": [
     "BAT",


### PR DESCRIPTION
Description:
Adds an optional mqtt_replace_spaces setting to replace spaces with underscores in MQTT topics.
This makes devices with spaces in their topic names compatible with Home Assistant.

`Before: RFLinkGateway/Alecto V4/55f8/READ/TEMP`
`After:  RFLinkGateway/Alecto_V4/55f8/READ/TEMP`